### PR TITLE
no need to `find` if nothing @changed

### DIFF
--- a/git-dirtyfiles
+++ b/git-dirtyfiles
@@ -28,8 +28,10 @@ if ($commit) {
     die "Fucking shell, how does it work?\n"
         if grep / /, @changed;
 
-    chomp(@changed = qx{find @changed -type f });
-    exit 1 unless $? == 0;
+    if (@changed) {
+        chomp(@changed = qx{find @changed -type f });
+        exit 1 unless $? == 0;
+    }
 }
 
 my $sep = $opt{0} ? "\0" : "\n";


### PR DESCRIPTION
this avoids an annoyance from Mac OS X find, which barfs when given
no starting path
