### PR TITLE
support files with (some) sorts of special characters in them

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -9,18 +9,18 @@
 # This program is in the public domain
 
 function typeof () {
-    filename=$1
-    case $filename in
+    filename="$1"
+    case "$filename" in
         *.pl | *.pm) echo perl; exit ;;
     esac
 
     line1=$(head -1 $1)
-    case $line1 in '#!'*perl )
+    case "$line1" in '#!'*perl )
         echo perl; exit ;;
     esac
 }
 
-if [ ! -z $COMMIT_OK ]; then
+if [ ! -z "$COMMIT_OK" ]; then
     exit 0;
 fi
 
@@ -39,8 +39,8 @@ for file in $(git diff --cached --name-only | sort) ; do
     echo "##  Checking file $file (type $type)"
     case $type in
         perl )
-            perl -cw $file || BAD=true
-            [ -x $file ] || { echo "File is not executable"; BAD=true; }
+            perl -cw -- "$file" || BAD=true
+            [ -x "$file" ] || { echo "File is not executable"; BAD=true; }
             ;;
         * )
             echo "Unknown file type: $file; no checks"
@@ -57,7 +57,7 @@ if $allOK; then
 else
     echo ''
     echo '## Aborting commit.  Failed checks:'
-    for file in $(echo $badFiles | tr ';' ' '); do
+    for file in $(echo "$badFiles" | tr ';' ' '); do
         echo "    $file"
     done
     exit 1;


### PR DESCRIPTION
This still doesn't make the script safe to use on repositories containing arbitrarily bad file names (because of the `for file in $(...)` construct). However it's better than not protecting at all.

My personal first rule for writing shell scripts is: Never use a variable unquoted.